### PR TITLE
Bugfix with floors that does NOT have Baldi as a potential Baldi NPC + Made logger's exceptions more understandable

### DIFF
--- a/TeacherAPI/TeacherPlugin.cs
+++ b/TeacherAPI/TeacherPlugin.cs
@@ -86,6 +86,7 @@ If you encounter an error, send me the Logs!", false);
         {
             if (floorObject.potentialBaldis.Count() <= 0)
             {
+                Log.LogWarning("potentialBaldis in " + floorObject.name + "is blank!");
                 return originalBaldiPerFloor[floorObject];
             }
             var baldis = (from x in floorObject.potentialBaldis
@@ -94,7 +95,12 @@ If you encounter an error, send me the Logs!", false);
             if (baldis.Length > 1)
             {
                 (from baldi in baldis select baldi.name).Print("Baldis", TeacherPlugin.Log);
-                MTM101BaldiDevAPI.CauseCrash(Info, new Exception("Multiple Baldis found in the level!"));
+                MTM101BaldiDevAPI.CauseCrash(Info, new Exception("Multiple Baldis found in " + floorObject.name + "!"));
+            }
+            else if (baldis.Length <= 0)
+            {
+                Log.LogWarning("No Baldi found in " + floorObject.name + "!");
+                return null;
             }
             return baldis.First();
         }

--- a/TeacherAPI/patches/LevelGeneratorPatches.cs
+++ b/TeacherAPI/patches/LevelGeneratorPatches.cs
@@ -21,7 +21,7 @@ namespace TeacherAPI.patches
             object itemAction(object obj)
             {
                 if (man.MainTeacherPrefab != null) return obj;
-                if (TeacherPlugin.Instance.potentialTeachers[__instance.ld].Count <= 0)
+                if (TeacherPlugin.Instance.potentialTeachers[__instance.ld].Count <= 0 || TeacherPlugin.Instance.originalBaldiPerFloor[__instance.ld] == null)
                 {
                     TeacherManager.DefaultBaldiEnabled = true;
                     return obj;
@@ -62,7 +62,7 @@ namespace TeacherAPI.patches
 
             void postfix()
             {
-                if (TeacherManager.DefaultBaldiEnabled) return;
+                if (TeacherManager.DefaultBaldiEnabled || TeacherPlugin.Instance.originalBaldiPerFloor[__instance.ld] == null) return;
                 var controlledRng = new System.Random(seed);
                 __instance.Ec.offices
                     .ForEach(office => __instance.Ec.BuildPosterInRoom(office, man.MainTeacherPrefab.Poster, controlledRng));


### PR DESCRIPTION
This was probably easy to fix, but at the same time I have a level object that has an NPC in `ld.potentialBaldis` instead of Baldi himself.

Every time `TeacherPlugin.Instance.originalBaldiPerFloor[levelobject]`'s Baldi prefab is `null`, revert the replacement to default potential NPC or Baldi.